### PR TITLE
Add Qiskit AerSimulator backend support and update CLI options

### DIFF
--- a/examples/netqmpi/roundrobin.py
+++ b/examples/netqmpi/roundrobin.py
@@ -16,27 +16,28 @@ def main(env: Environment = None):
 
     with comm:
         if rank == 0:
-            circuit = env.create_circuit(num_qubits=1, num_clbits=0)
+            circuit = env.create_circuit(num_qubits=1, num_clbits=1)
             circuit.h(0)
             print_info(f"start to teleport a qubit to rank_{next_rank}", rank)
             circuit.qsend([0], next_rank)
-            circuit.build()
         else:
             circuit = env.create_circuit(num_qubits=1, num_clbits=1)
             print_info(f"starting to receive a qubit from {previous_rank}", rank)
             circuit.qrecv([0], previous_rank)
+            print_info(f"received a qubit from rank_{previous_rank}", rank)
 
             # Send to next rank only if not the last rank
             if rank != size - 1:
-                print_info(f"received a qubit from rank_{previous_rank}", rank)
                 circuit.qsend([0], next_rank)
                 print_info(f"sent a qubit to rank_{next_rank}", rank)
-                circuit.build()
             else:
                 circuit.measure(0, 0)
-                result = circuit.build()
-                comm.flush()
-                print_info(f"measurement {result['results'][0]}", rank)
+                print_info(f"measurement complete", rank)
+
+    results = comm.results
+
+    if rank == 0:
+        print_info(f"measure: {results}", rank)
 
 if __name__ == "__main__":
     main()

--- a/examples/netqmpi/send_recv.py
+++ b/examples/netqmpi/send_recv.py
@@ -15,7 +15,7 @@ def main(env: Environment = None):
 
     with comm: # Sólo se ejecuta lo que hay en el with
         if rank == 0:
-            circuit = env.create_circuit(num_qubits=1, num_clbits=0)
+            circuit = env.create_circuit(num_qubits=1, num_clbits=1)
             circuit.h(0)
             comm.qsend(circuit, [0], next_rank)
         else:

--- a/netqmpi/runtime/adapters/__init__.py
+++ b/netqmpi/runtime/adapters/__init__.py
@@ -1,6 +1,11 @@
 """
 Backend adapters for NetQMPI.
 
-This module contains the backend-specific adapters (NetQASM and CUNQA for now) that implement 
+This module contains the backend-specific adapters (NetQASM, CUNQA, and Aer) that implement
 the interfaces defined in the SDK.
+
+Available adapter packages:
+- netqmpi.runtime.adapters.netqasm  — NetQASM simulator backend
+- netqmpi.runtime.adapters.cunqa   — CUNQA QPU backend
+- netqmpi.runtime.adapters.aer     — Qiskit AerSimulator backend
 """

--- a/netqmpi/runtime/adapters/aer/__init__.py
+++ b/netqmpi/runtime/adapters/aer/__init__.py
@@ -1,0 +1,17 @@
+"""Qiskit AerSimulator runtime adapter for NetQMPI.
+
+This package exposes the AerSimulator-specific runtime adapter classes
+used by NetQMPI to simulate distributed quantum programs on a single
+monolithic QuantumCircuit.
+"""
+from netqmpi.runtime.adapters.aer.aer_circuit import AerCircuitAdapter
+from netqmpi.runtime.adapters.aer.aer_executor import AerExecutorAdapter
+from netqmpi.runtime.adapters.aer.aer_communicator import AerCommunicator
+from netqmpi.runtime.adapters.aer.aer_run_config import AerSimulatorConfig
+
+__all__ = [
+    "AerCircuitAdapter",
+    "AerExecutorAdapter",
+    "AerCommunicator",
+    "AerSimulatorConfig",
+]

--- a/netqmpi/runtime/adapters/aer/aer_circuit.py
+++ b/netqmpi/runtime/adapters/aer/aer_circuit.py
@@ -1,0 +1,322 @@
+"""
+Circuit adapter for Qiskit AerSimulator.
+
+Translates SDK operations into Qiskit gates appended directly to a
+shared global QuantumCircuit owned by the executor.  Every local qubit
+index is shifted by the rank's offset before being written to the global
+register.
+"""
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from qiskit import QuantumCircuit  # type: ignore[import-not-found]
+
+from netqmpi.sdk.circuit import Circuit
+from netqmpi.sdk.operations import (
+    Operation,
+    Gate, ControlledGate, ClassicalControlledGate,
+    Measure, Reset, Barrier,
+    OperationContainer,
+    QSend, QRecv, QScatter, QGather, Expose, Unexpose,
+)
+
+if TYPE_CHECKING:
+    from netqmpi.runtime.adapters.aer.aer_communicator import AerCommunicator
+
+
+class AerCircuitAdapter(Circuit):
+    """
+    Circuit adapter that writes operations into a shared global QuantumCircuit.
+
+    Each rank owns a contiguous slice ``[qubit_offset, qubit_offset + num_qubits)``
+    of the global qubit register and the analogous slice of the classical
+    register.  All translate methods map local indices to global indices
+    before appending gates.
+
+    For qsend, the destination offset within the same circuit group is
+    computed as ``group_base + dest_rank * num_qubits``, which remains
+    valid regardless of how many circuit groups exist.
+    """
+
+    def __init__(
+        self,
+        num_qubits: int,
+        num_clbits: int,
+        comm: "AerCommunicator",
+        global_circuit: "QuantumCircuit",
+        qubit_offset: int,
+        clbit_offset: int,
+        group_base: int,
+    ) -> None:
+        """
+        Initialize the AerCircuitAdapter.
+
+        Args:
+            num_qubits: Number of qubits for this rank's circuit slice.
+            num_clbits: Number of classical bits for this rank's circuit slice.
+            comm: Communicator owning this rank.
+            global_circuit: Shared QuantumCircuit for all ranks.
+            qubit_offset: Global qubit index where this rank's slice starts.
+            clbit_offset: Global clbit index where this rank's slice starts.
+            group_base: Global qubit index where this circuit group starts
+                (used to compute qsend destination offsets).
+        """
+        super().__init__(num_qubits, num_clbits, comm)
+        self._global_circuit = global_circuit
+        self._offset = qubit_offset
+        self._clbit_offset = clbit_offset
+        self._group_base = group_base
+        self._config = comm._config
+
+    # ------------------------------------------------------------------
+    # Translation methods
+    # ------------------------------------------------------------------
+
+    def _translate_gate(self, op: Gate) -> None:
+        """
+        Translate a single-qubit (or two-qubit SWAP) gate.
+
+        Args:
+            op: Gate operation to translate.
+        """
+        q = op.qubits[0] + self._offset
+        gate_map = {
+            "H":    lambda: self._global_circuit.h(q),
+            "X":    lambda: self._global_circuit.x(q),
+            "Y":    lambda: self._global_circuit.y(q),
+            "Z":    lambda: self._global_circuit.z(q),
+            "S":    lambda: self._global_circuit.s(q),
+            "SDG":  lambda: self._global_circuit.sdg(q),
+            "T":    lambda: self._global_circuit.t(q),
+            "TDG":  lambda: self._global_circuit.tdg(q),
+            "RX":   lambda: self._global_circuit.rx(op.params[0], q),
+            "RY":   lambda: self._global_circuit.ry(op.params[0], q),
+            "RZ":   lambda: self._global_circuit.rz(op.params[0], q),
+            "SWAP": lambda: self._global_circuit.swap(
+                op.qubits[0] + self._offset,
+                op.qubits[1] + self._offset,
+            ),
+        }
+        if op.name in gate_map:
+            gate_map[op.name]()
+
+    def _translate_controlled_gate(self, op: ControlledGate) -> None:
+        """
+        Translate a controlled gate (CX, CZ, CRZ, CCX).
+
+        Args:
+            op: Controlled gate operation to translate.
+        """
+        target_name = op.targets[0].name
+        ctrl = [c + self._offset for c in op.controls]
+        tgt = [q + self._offset for q in op.targets[0].qubits]
+
+        if target_name == "X":
+            if len(ctrl) == 1:
+                self._global_circuit.cx(ctrl[0], tgt[0])
+            elif len(ctrl) == 2:
+                self._global_circuit.ccx(ctrl[0], ctrl[1], tgt[0])
+        elif target_name == "Z" and len(ctrl) == 1:
+            self._global_circuit.cz(ctrl[0], tgt[0])
+        elif target_name == "RZ" and len(ctrl) == 1:
+            self._global_circuit.crz(op.targets[0].params[0], ctrl[0], tgt[0])
+
+    def _translate_classical_controlled_gate(self, op: ClassicalControlledGate) -> None:
+        """
+        Translate a classically controlled gate.
+
+        Args:
+            op: Classically controlled gate operation.
+
+        Raises:
+            NotImplementedError: Always; not yet supported for this backend.
+        """
+        raise NotImplementedError(
+            "ClassicalControlledGate is not yet implemented for the Aer backend."
+        )
+
+    def _translate_measure(self, op: Measure) -> None:
+        """
+        Translate a measurement into a global-circuit instruction.
+
+        Args:
+            op: Measurement operation to translate.
+        """
+        self._global_circuit.measure(
+            op.qubits[0] + self._offset,
+            op.cbit + self._clbit_offset,
+        )
+
+    def _translate_reset(self, op: Reset) -> None:
+        """
+        Translate a reset into a global-circuit instruction.
+
+        Args:
+            op: Reset operation to translate.
+        """
+        self._global_circuit.reset(op.qubits[0] + self._offset)
+
+    def _translate_barrier(self, op: Barrier) -> None:
+        """
+        Translate a barrier across all global qubits owned by this rank.
+
+        Args:
+            op: Barrier operation to translate.
+        """
+        if op.qubits:
+            global_qubits = [q + self._offset for q in op.qubits]
+        else:
+            global_qubits = list(range(self._offset, self._offset + self._num_qubits))
+        self._global_circuit.barrier(global_qubits)
+
+    def _translate_operation_container(self, op: OperationContainer) -> None:
+        """
+        Translate an operation container by translating each leaf operation.
+
+        Args:
+            op: Operation container to translate.
+        """
+        for child in op.flatten():
+            self.translate(child)
+
+    def _translate_qsend(self, op: QSend) -> None:
+        """
+        Translate a quantum send into the global circuit.
+
+        In ``swap`` mode, inserts a SWAP gate between the source qubit slot
+        and the matching slot on the destination rank within the same circuit
+        group.  The destination offset is ``group_base + dest_rank * num_qubits``,
+        which remains correct across multiple circuit groups.
+
+        Args:
+            op: Quantum send operation to translate.
+
+        Raises:
+            NotImplementedError: When ``transfer_mode`` is ``"teleport"``.
+        """
+        if self._config.transfer_mode == "swap":
+            dest_offset = self._group_base + op.dest_rank * self._num_qubits
+            for q in op.qubits:
+                self._global_circuit.swap(q + self._offset, q + dest_offset)
+        else:
+            raise NotImplementedError(
+                "teleport mode is not yet implemented; use transfer_mode='swap'"
+            )
+
+    def _translate_qrecv(self, op: QRecv) -> None:
+        """
+        Translate a quantum receive (no-op for the monolithic circuit model).
+
+        After a ``qsend`` SWAP the transferred state is already in the
+        destination slot, so the receiver needs no circuit action.
+
+        Args:
+            op: Quantum receive operation to translate.
+        """
+
+    def _translate_qscatter(self, op: QScatter) -> None:
+        """
+        Translate a quantum scatter operation.
+
+        Args:
+            op: Quantum scatter operation to translate.
+
+        Raises:
+            NotImplementedError: Always; not yet implemented for this backend.
+        """
+        raise NotImplementedError(
+            "QScatter is not yet implemented for the Aer backend."
+        )
+
+    def _translate_qgather(self, op: QGather) -> None:
+        """
+        Translate a quantum gather operation.
+
+        Args:
+            op: Quantum gather operation to translate.
+
+        Raises:
+            NotImplementedError: Always; not yet implemented for this backend.
+        """
+        raise NotImplementedError(
+            "QGather is not yet implemented for the Aer backend."
+        )
+
+    def _translate_expose(self, op: Expose) -> None:
+        """
+        Translate an expose operation.
+
+        Args:
+            op: Expose operation to translate.
+
+        Raises:
+            NotImplementedError: Always; not yet implemented for this backend.
+        """
+        raise NotImplementedError(
+            "Expose is not yet implemented for the Aer backend."
+        )
+
+    def _translate_unexpose(self, op: Unexpose) -> None:
+        """
+        Translate an unexpose operation.
+
+        Args:
+            op: Unexpose operation to translate.
+
+        Raises:
+            NotImplementedError: Always; not yet implemented for this backend.
+        """
+        raise NotImplementedError(
+            "Unexpose is not yet implemented for the Aer backend."
+        )
+
+    # ------------------------------------------------------------------
+    # Dispatch table (mirrors the pattern in CunqaCircuitAdapter)
+    # ------------------------------------------------------------------
+
+    _DISPATCH: dict = {}
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        cls._DISPATCH = {}
+
+    def _build_dispatch(self):
+        """
+        Build the dispatch table mapping operation types to translation methods.
+
+        Returns:
+            A dict from operation type to the corresponding translate method.
+        """
+        return {
+            ClassicalControlledGate: self._translate_classical_controlled_gate,
+            ControlledGate:          self._translate_controlled_gate,
+            Gate:                    self._translate_gate,
+            Measure:                 self._translate_measure,
+            Reset:                   self._translate_reset,
+            Barrier:                 self._translate_barrier,
+            OperationContainer:      self._translate_operation_container,
+            QSend:                   self._translate_qsend,
+            QRecv:                   self._translate_qrecv,
+            QScatter:                self._translate_qscatter,
+            QGather:                 self._translate_qgather,
+            Expose:                  self._translate_expose,
+            Unexpose:                self._translate_unexpose,
+        }
+
+    def translate(self, op: Operation) -> Any:
+        """
+        Dispatch an operation and return the shared global QuantumCircuit.
+
+        Args:
+            op: Operation to translate.
+
+        Returns:
+            The shared global QuantumCircuit after appending the operation.
+
+        Raises:
+            TypeError: If the operation type is unknown.
+        """
+        super().translate(op)
+        return self._global_circuit

--- a/netqmpi/runtime/adapters/aer/aer_communicator.py
+++ b/netqmpi/runtime/adapters/aer/aer_communicator.py
@@ -1,0 +1,126 @@
+"""
+Communicator adapter for Qiskit AerSimulator.
+
+Manages the context lifecycle for a single rank.  The global
+QuantumCircuit is owned by :class:`AerExecutorAdapter`; this class
+coordinates the barrier synchronization that ensures all ranks have
+finished building their circuits before the simulation runs, and that
+all ranks receive results before any of them continue past the
+``with env.comm:`` block.
+"""
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING, List, Optional
+
+from netqmpi.sdk.communicator import QMPICommunicator
+from netqmpi.runtime.adapters.aer.aer_run_config import AerSimulatorConfig
+
+if TYPE_CHECKING:
+    from netqmpi.runtime.adapters.aer.aer_executor import AerExecutorAdapter
+
+
+class AerCommunicator(QMPICommunicator):
+    """
+    AerSimulator-backed communicator for a single rank.
+
+    All N ranks run concurrently in separate threads.  ``__exit__`` uses
+    a :class:`threading.Barrier` to synchronise them:
+
+    1. Every rank finishes building its circuit ops and reaches the barrier.
+    2. One designated thread translates all circuits (in rank order, so
+       gate ordering in the global circuit is deterministic) and runs the
+       simulation.
+    3. All threads are released with results available and continue past
+       the ``with env.comm:`` block simultaneously.
+
+    The barrier and class-level communicator list are reset after the last
+    rank exits so the adapter is reusable within the same process.
+
+    Args:
+        rank: Numeric index of the current rank.
+        size: Total number of ranks.
+        config: AerSimulator-specific configuration.
+        executor: Executor that owns the global QuantumCircuit.
+    """
+
+    # All AerCommunicator instances for the current run (rank-ordered).
+    communicators: List["AerCommunicator"] = []
+    # Set by AerExecutorAdapter.build_apps after all communicators are created.
+    _barrier: Optional[threading.Barrier] = None
+
+    def __init__(
+        self,
+        rank: int,
+        size: int,
+        config: AerSimulatorConfig,
+        executor: "AerExecutorAdapter",
+    ) -> None:
+        """
+        Initialize the communicator.
+
+        Args:
+            rank: Numeric index of the current rank.
+            size: Total number of ranks in the communicator.
+            config: AerSimulator-specific configuration.
+            executor: Executor that owns the global QuantumCircuit.
+        """
+        super().__init__(rank, size)
+        self._config = config
+        self._executor = executor
+        AerCommunicator.communicators.append(self)
+
+    def __enter__(self) -> "AerCommunicator":
+        """
+        Enter the communicator context.
+
+        Returns:
+            The communicator instance.
+        """
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        """
+        Synchronise all ranks, run the simulation, and broadcast results.
+
+        Three-phase barrier protocol:
+
+        * **Phase 1** – all ranks wait until every rank has finished
+          appending operations to its circuit.
+        * **Phase 2** – one designated thread (party 0) translates all
+          circuits into the global QuantumCircuit in rank order and
+          submits the simulation.  All other threads block here.
+        * **Phase 3** – all threads are released once results are
+          available; the designated thread resets class-level state for
+          the next run.
+
+        After this method returns, ``env.comm.results`` is populated for
+        every rank.
+
+        Args:
+            exc_type: Exception type, if one was raised.
+            exc_val: Exception instance, if one was raised.
+            exc_tb: Traceback, if one was raised.
+        """
+        # Phase 1: wait for every rank to finish building its circuit.
+        party_id = AerCommunicator._barrier.wait()
+
+        # Phase 2: one thread translates all circuits in rank order and
+        # runs the simulation.  Rank order is deterministic because
+        # build_apps creates communicators 0..size-1 in sequence.
+        if party_id == 0:
+            for comm in AerCommunicator.communicators:
+                for circuit in comm.circuits:
+                    circuit.translate(circuit.ops)
+            self._executor._run_simulation()
+
+        # Phase 3: all threads block until the simulation is done, then
+        # the designated thread resets shared state.
+        AerCommunicator._barrier.wait()
+
+        if party_id == 0:
+            self._executor._reset()
+            AerCommunicator.communicators = []
+            AerCommunicator._barrier = None
+
+        return None

--- a/netqmpi/runtime/adapters/aer/aer_executor.py
+++ b/netqmpi/runtime/adapters/aer/aer_executor.py
@@ -1,0 +1,190 @@
+"""
+Executor adapter for Qiskit AerSimulator.
+
+This module provides the :class:`AerExecutorAdapter` implementation of
+the :class:`~netqmpi.runtime.executor.Executor` interface for running
+NetQMPI applications on Qiskit's AerSimulator backend.
+"""
+from __future__ import annotations
+
+import threading
+from typing import Any, List, Tuple
+
+from netqmpi.runtime.executor import Executor
+from netqmpi.sdk.environment import Environment
+from netqmpi.runtime.adapters.aer.aer_circuit import AerCircuitAdapter
+from netqmpi.runtime.adapters.aer.aer_communicator import AerCommunicator
+from netqmpi.runtime.adapters.aer.aer_run_config import AerSimulatorConfig
+from netqmpi.helpers import load_main
+
+
+class AerExecutorAdapter(Executor):
+    """
+    Executor adapter that runs NetQMPI apps on Qiskit's AerSimulator.
+
+    Owns a single global QuantumCircuit that grows with every
+    :meth:`create_circuit` call.  Each call allocates a new contiguous
+    *circuit group* of ``size * num_qubits`` qubits (one slice per rank),
+    so any number of circuits can be created per rank while the SWAP-based
+    qsend offsets remain consistent.
+
+    :meth:`run` launches every rank in a separate thread.
+    :meth:`build_apps` installs a :class:`threading.Barrier` on
+    :class:`AerCommunicator` so that ``__exit__`` can synchronise all
+    threads before and after the simulation.
+    """
+
+    def __init__(self, size: int, config: AerSimulatorConfig = None) -> None:
+        """
+        Initialize the AerSimulator executor adapter.
+
+        Args:
+            size: Number of parallel ranks to simulate.
+            config: AerSimulator-specific configuration.  Defaults to
+                :class:`AerSimulatorConfig` with its built-in defaults.
+        """
+        _config = config or AerSimulatorConfig()
+        super().__init__(size, _config)
+        # Re-narrow the type so the checker knows we have AerSimulatorConfig.
+        self._config: AerSimulatorConfig = _config
+        self._global_circuit = None
+        # Each entry: (num_qubits, num_clbits, qubit_base, clbit_base)
+        self._circuit_groups: List[Tuple[int, int, int, int]] = []
+        self._qubit_count: int = 0
+        self._clbit_count: int = 0
+        # Protects global-circuit mutations when ranks call create_circuit concurrently.
+        self._lock = threading.Lock()
+
+    def create_circuit(
+        self,
+        num_qubits: int,
+        num_clbits: int,
+        comm: AerCommunicator,
+    ) -> AerCircuitAdapter:
+        """
+        Create an AerCircuitAdapter and extend the global circuit if needed.
+
+        Thread-safe: multiple ranks may call this simultaneously.  The
+        first rank to request a given circuit group allocates
+        ``size * num_qubits`` new qubits for that group; subsequent ranks
+        reuse the already-allocated group.
+
+        Args:
+            num_qubits: Number of qubits for this rank's circuit slice.
+            num_clbits: Number of classical bits for this rank's circuit slice.
+            comm: Communicator associated with this rank.
+
+        Returns:
+            An :class:`AerCircuitAdapter` writing into the global circuit at
+            the correct qubit/clbit offset for this rank and circuit group.
+        """
+        with self._lock:
+            if self._global_circuit is None:
+                from qiskit import QuantumCircuit  # type: ignore[import-not-found]
+                self._global_circuit = QuantumCircuit(0, 0)
+
+            # len(comm.circuits) is the index of the circuit being created:
+            # Environment.create_circuit() appends AFTER this method returns.
+            circuit_index = len(comm.circuits)
+
+            if circuit_index >= len(self._circuit_groups):
+                # First rank for this group: allocate slots for all ranks.
+                from qiskit import QuantumRegister, ClassicalRegister  # type: ignore[import-not-found]
+                qr = QuantumRegister(self._size * num_qubits, f'qr{circuit_index}')
+                cr = ClassicalRegister(self._size * num_clbits, f'cr{circuit_index}')
+                self._global_circuit.add_register(qr)
+                self._global_circuit.add_register(cr)
+                self._circuit_groups.append(
+                    (num_qubits, num_clbits, self._qubit_count, self._clbit_count)
+                )
+                self._qubit_count += self._size * num_qubits
+                self._clbit_count += self._size * num_clbits
+
+            _, _, qubit_base, clbit_base = self._circuit_groups[circuit_index]
+            qubit_offset = qubit_base + comm._rank * num_qubits
+            clbit_offset = clbit_base + comm._rank * num_clbits
+
+            return AerCircuitAdapter(
+                num_qubits, num_clbits, comm,
+                self._global_circuit, qubit_offset, clbit_offset, qubit_base,
+            )
+
+    def build_apps(self, file: str, size: int) -> List[Any]:
+        """
+        Build one callable wrapper per rank and install the sync barrier.
+
+        Creates all :class:`AerCommunicator` instances and then installs
+        a :class:`threading.Barrier` on the class so that every rank's
+        ``__exit__`` can synchronise before the simulation runs.
+
+        Args:
+            file: Path to the NetQMPI Python script defining ``main()``.
+            size: Number of ranks to instantiate.
+
+        Returns:
+            A list of zero-argument callables, one per rank.
+        """
+        main_func = load_main(file)
+        apps = []
+        for rank in range(size):
+            comm = AerCommunicator(rank, size, self._config, self)
+            env = Environment(comm, self)
+            wrapped_main = lambda env=env: main_func(env=env)
+            apps.append(wrapped_main)
+        # Install the barrier after all communicators exist so __exit__ can use it.
+        AerCommunicator._barrier = threading.Barrier(size)
+        return apps
+
+    def run(self, apps: List[Any]) -> None:
+        """
+        Launch every rank in a separate thread and wait for all to finish.
+
+        Running ranks concurrently is required so that the
+        :class:`threading.Barrier` in ``AerCommunicator.__exit__`` can
+        synchronise them: all N threads must reach the barrier for any of
+        them to proceed past it.
+
+        Args:
+            apps: List of callables returned by :meth:`build_apps`.
+        """
+        threads = [threading.Thread(target=app) for app in apps]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+    # ------------------------------------------------------------------
+    # Internal helpers called by AerCommunicator.__exit__
+    # ------------------------------------------------------------------
+
+    def _run_simulation(self) -> None:
+        """
+        Submit the global circuit to AerSimulator and broadcast counts.
+
+        Called by the designated thread inside ``AerCommunicator.__exit__``
+        after all ranks have finished building their circuits.
+        """
+        from qiskit_aer import AerSimulator  # type: ignore[import-not-found]
+
+        run_kwargs: dict = {"shots": self._config.shots}
+        if self._config.seed_simulator is not None:
+            run_kwargs["seed_simulator"] = self._config.seed_simulator
+
+        simulator = AerSimulator()
+        job = simulator.run(self._global_circuit, **run_kwargs)
+        counts = job.result().get_counts()
+
+        for comm in AerCommunicator.communicators:
+            comm.results = counts
+
+    def _reset(self) -> None:
+        """
+        Reset executor state for the next run.
+
+        Called by the designated thread inside ``AerCommunicator.__exit__``
+        after all ranks have received their results.
+        """
+        self._global_circuit = None
+        self._circuit_groups = []
+        self._qubit_count = 0
+        self._clbit_count = 0

--- a/netqmpi/runtime/adapters/aer/aer_run_config.py
+++ b/netqmpi/runtime/adapters/aer/aer_run_config.py
@@ -1,0 +1,33 @@
+"""
+Backend-specific configuration for Qiskit AerSimulator runs.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from netqmpi.runtime.run_config import RunConfig
+
+
+@dataclass
+class AerSimulatorConfig(RunConfig):
+    """
+    Extension of :class:`~netqmpi.runtime.run_config.RunConfig` with
+    Qiskit AerSimulator-specific fields.
+
+    Attributes:
+        shots: Number of simulation shots.
+        transfer_mode: Qubit transfer protocol for qsend/qrecv.
+            ``"swap"`` (default) inserts an unphysical SWAP gate between
+            the source and destination qubit slots — produces shallower
+            circuits and is easier to debug, but does not model a real
+            quantum-network transfer.
+            ``"teleport"`` implements a physically realistic teleportation
+            circuit using mid-circuit measurement and classical feedforward,
+            which requires AerSimulator dynamic-circuits support.
+        seed_simulator: Optional RNG seed for reproducible simulations.
+    """
+
+    shots: int = 1024
+    transfer_mode: str = "swap"        # "swap" | "teleport"
+    seed_simulator: Optional[int] = None

--- a/netqmpi/runtime/cli.py
+++ b/netqmpi/runtime/cli.py
@@ -67,6 +67,14 @@ def main():
     backend_group = parser.add_mutually_exclusive_group()
     backend_group.add_argument("--netqasm", action="store_true", help="Use NetQASM backend")
     backend_group.add_argument("--cunqa", action="store_true", help="Use CUNQA backend")
+    backend_group.add_argument("--aer", action="store_true", help="Use Qiskit AerSimulator backend")
+
+    parser.add_argument(
+        "--transfer-mode",
+        choices=["swap", "teleport"],
+        default="swap",
+        help="Qubit transfer mode for the Aer backend: 'swap' (default) or 'teleport'",
+    )
 
     parser.add_argument(
         "--shots", 
@@ -92,6 +100,14 @@ def main():
 
         config = CunqaRunConfig(shots=(args.shots or 1024))
         executor = CunqaExecutorAdapter(args.num_procs, config=config)
+    elif args.aer:
+        from netqmpi.runtime.adapters.aer import AerExecutorAdapter, AerSimulatorConfig
+
+        config = AerSimulatorConfig(
+            shots=(args.shots or 1024),
+            transfer_mode=args.transfer_mode,
+        )
+        executor = AerExecutorAdapter(args.num_procs, config=config)
     else:
         from netqmpi.runtime.adapters.netqasm import NetQASMExecutorAdapter, NetQASMRunConfig
 


### PR DESCRIPTION
- Implement AerExecutorAdapter and AerCircuitAdapter for Qiskit AerSimulator.
- Introduce AerCommunicator for managing rank synchronization.
- Add AerSimulatorConfig for backend-specific configuration.
- Update CLI to include options for selecting AerSimulator and transfer modes.
- Modify example scripts to use the new Aer backend.